### PR TITLE
fix exit status

### DIFF
--- a/examples/skip
+++ b/examples/skip
@@ -42,7 +42,7 @@ sub usage {
    --bufsize n   use n instead of default $BUFSIZ as buffer size
    --silent      don't give error if the input is too short
 ";
-    exit @_ ? 1 : 0;
+    exit(@_ ? 1 : 0);
 }
 
 sub resource_rss {


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit @_ ? 1 : 0` parses as `(exit @_) ? 1 : 0`, which is not what was intended.